### PR TITLE
fix: now allowing array field types (no difference in es) + assert

### DIFF
--- a/src/util/model.js
+++ b/src/util/model.js
@@ -8,10 +8,10 @@ module.exports = ({
       typeof specs.fields === "object" && !Array.isArray(specs.fields),
       "Model definition expected to be of type object."
     );
-    assert(
-      Object.values(specs.fields).every(f => fieldDefinitions[f.endsWith("[]") ? f.slice(0, -2) : f] !== undefined),
-      "Unknown field type given."
-    );
+    Object.values(specs.fields).forEach(fieldType => assert(
+      fieldDefinitions[fieldType.endsWith("[]") ? fieldType.slice(0, -2) : fieldType] !== undefined,
+      `Unknown field type given: ${fieldType}`
+    ));
     return Object.assign({}, specs, {
       fields: Object
         .entries(specs.fields)

--- a/src/util/model.js
+++ b/src/util/model.js
@@ -8,10 +8,16 @@ module.exports = ({
       typeof specs.fields === "object" && !Array.isArray(specs.fields),
       "Model definition expected to be of type object."
     );
+    assert(
+      Object.values(specs.fields).every(f => fieldDefinitions[f.endsWith("[]") ? f.slice(0, -2) : f] !== undefined),
+      "Unknown field type given."
+    );
     return Object.assign({}, specs, {
       fields: Object
         .entries(specs.fields)
-        .reduce((prev, [key, value]) => Object.assign(prev, { [key]: fieldDefinitions[value] }), {})
+        .reduce((prev, [key, value]) => Object.assign(prev, {
+          [key]: fieldDefinitions[value.endsWith("[]") ? value.slice(0, -2) : value]
+        }), {})
     });
   }
 });

--- a/test/models/address.json
+++ b/test/models/address.json
@@ -6,6 +6,7 @@
     "country": "string",
     "centre": "point",
     "area": "shape",
-    "timezone": "string"
+    "timezone": "string",
+    "keywords": "string[]"
   }
 }


### PR DESCRIPTION
https://github.com/loopmediagroup/es-alchemy/issues/52